### PR TITLE
Added reference to ES module file in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 	"name": "dotdotdot-js",
 	"version": "4.0.5",
 	"main": "dist/dotdotdot.js",
+	"module": "dist/dotdotdot.es6.js",
 	"author": "Fred Heusschen <info@frebsite.nl>",
 	"license": "CC-BY-NC-4.0",
 	"repository": {


### PR DESCRIPTION
Currently `Dotdotdot` cannot be imported automatically as an ES module by using a syntax such as:
`import Dotdotdot from 'dotdotdot-js';`

Users of the library need to dig in the code and figure out that the file exporting an ES module in, in fact, `dist/dotdotdot.es6.js` and import from there.

By adding a `module` property to `package.json` this helps automatically resolve to the ES module file.

Solves FrDH/dotdotdot-js#160