### PR TITLE
Build task now creates pkg.module ES5-compatible code.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,6 +37,13 @@ const jsES6 = ( cb ) => {
 		.pipe( gulp.dest( 'dist' ) );
 };
 
+/** Save plugin to be used with bundlers that support the pkg.module definition. */
+const jsESM = ( cb ) => {
+	return transpile( 'es5', 'es6' )
+		.pipe( rename( 'dotdotdot.esm.js' ) )
+		.pipe( gulp.dest( 'dist' ) );
+};
+
 /** Save plugin to be used with UMD pattern. */
 const jsUMD = ( cb ) => {
 	return transpile( 'es5', 'umd' )
@@ -44,7 +51,7 @@ const jsUMD = ( cb ) => {
 		.pipe( gulp.dest( 'dist' ) );
 };
 
-exports.default = gulp.parallel( js, jsES6, jsUMD );
+exports.default = gulp.parallel( js, jsES6, jsESM, jsUMD );
 
 // Watch task 'gulp watch': Starts a watch on JS tasks
 const watch = ( cb ) => {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "dotdotdot-js",
 	"version": "4.0.6",
 	"main": "dist/dotdotdot.js",
-	"module": "dist/dotdotdot.es6.js",
+	"module": "dist/dotdotdot.esm.js",
 	"author": "Fred Heusschen <info@frebsite.nl>",
 	"license": "CC-BY-NC-4.0",
 	"repository": {


### PR DESCRIPTION
Resolves #166

I've done some follow-up research related to my initial PR #165, and it looks like the files indicated in the `pkg.module` should **ONLY** contain `export` statements (which are ES6/ES2015-specific), but the rest of the code should _only use syntax features that the target environments support_.
- [See this indication in the `rollup` wiki](https://github.com/rollup/rollup/wiki/pkg.module)
- [See this indication in the `webpack` guide](https://webpack.js.org/guides/author-libraries/#final-steps)

To solve this, I've created a new gulp task that generates an `.esm` file that uses the `export default` statement, but all other code is ES5-compatible. Decided to use `esm` because [it's suggested in the `rollup` wiki](https://github.com/rollup/rollup/wiki/pkg.module) and I noticed [other libraries](https://github.com/vuejs/vue/blob/29e745f99f43d0629df547da80b016996ae70872/package.json#L6) use it too.

I also changed `package.json` so that the `module` property now links to this `.esm` file.

Did not touch the build step for the `.es6` version to maintain backwards compatibility for users of your library who are using `import Dotdotdot from 'dotdotdot-js/dist/dotdotdot.es6.js`